### PR TITLE
Restructure main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
 # awesome-maritime-robotics
 Repo for mapping all the open source robotics software, including the ones from this organization
 
-## Drivers
-- [ping360_sonar](https://github.com/CentraleNantesRobotics/ping360_sonar)
-
-## Simulation examples
-- [SUAVE](https://github.com/kas-lab/suave/blob/main/README.md) An Exemplar for Self-Adaptive Underwater Vehicles
-- [REMARO Summer School Delft 2022 - Underwater robotics hackathon](https://github.com/remaro-network/tudelft_hackathon)
+## Simulation environments
+### Gazebo
+- [VRX Boat Simulation](https://github.com/osrf/vrx) gazebosim example.
 - [Bluerov2](https://github.com/clydemcqueen/bluerov2_ignition) gazebosim model.
 - [LRAUV](https://github.com/osrf/lrauv) gazebosim example. Contains DVL.
-- [VRX Boat Simulation](https://github.com/osrf/vrx) gazebosim example.
-- [MBZIRC](https://github.com/osrf/mbzirc) Boat and aerial drone simulation. Contains radar.
 - [Orca4](https://github.com/clydemcqueen/orca4)
+- [SUAVE](https://github.com/kas-lab/suave/blob/main/README.md) An Exemplar for Self-Adaptive Underwater Vehicles
+- [REMARO Summer School Delft 2022 - Underwater robotics hackathon](https://github.com/remaro-network/tudelft_hackathon)
+- [MBZIRC](https://github.com/osrf/mbzirc) Boat and aerial drone simulation. Contains radar.
+
+### Other
 - [Stonefish](https://stonefish.readthedocs.io/en/latest/) is a C++ library combining a physics engine and a lightweight rendering pipeline.
+- [TurtleBoat](https://github.com/bartboogmans/TurtleBoat) is an interactive node, similar to turtlebot, but then with vessel dynamics
 
-## Data
-- [REMARO data](https://github.com/remaro-network/remaro_data)
+## Actuator control
+Modules that make sure that actuators follow a desired reference. 
+- The [general ros2 control community](https://control.ros.org/master/index.html)
 
-## Control effort generation - Control effort allocation:
+## Motion control modules
+Components that attempt to control the vessels motion to follow a reference state. 
+
+### Dynamical positioning / station keeping
+Full control over the pose of the vessel, generally for slow positioning, docking or station-keeping
+- ...
+
+### Heading / Velocity control
+Approaches that are tailored to function with high surge speed, commonly neglecting drift and actuation in sway direction. 
+- ...
+
+### Other approaches
+- ...
+
+## Control effort allocation / Thruster-managers
+Modules that attempt to best satisfy a reference resultant force by the ships actuators, given a certain thruster layout. 
 - [MVP-Control](https://github.com/uri-ocean-robotics/mvp_control): A generic vehicle low-level vehicle controller (implements a control allocation algorithm with quadratic programming).
 
 ## Planning/Guidance mission-planning:
 - [MVP-Mission](https://github.com/uri-ocean-robotics/mvp_mission): A generic behavior-based state-oriented mission planner. It contains common behaviors for marine guidance.
+
+## Drivers
+- [ping360_sonar](https://github.com/CentraleNantesRobotics/ping360_sonar)
+
+## Open access datasets of marine drone operation
+- [REMARO data](https://github.com/remaro-network/remaro_data)


### PR DESCRIPTION
I think a good overview of projects/tools is one of the most important things the ros-maritime group can offer. 
This is an attempt to restructure the list of projects, such that people can hopefully find modules that they are interested in. 

The main changes are as follows:
- The simulation environment items have been sorted in gazebo and non gazebo groups. I checked the projects and apparently they are almost all running in gazebo. It can be helpful to show that this is apparently convenient for many people. 
- Added sections: Motion control - Control effort allocation - Planning/guidance.
I see these groups as the main building blocks that projects or modules can be categorized in. A working vessel control system needs all these modules, but theoretically they can be developed independently from one-another. 
- For many of these modules, there are actually only a few common approaches to solve them, and thus it would be convenient if they are listed according to the concept that they work on. I added the two most common approaches "dynamical positioning" and "heading+speed control" under section motion control modules. 


Still a lot of these topics need links to relevant projects to make this repository reasonably useful. This PR is a proposal to strengthen the structure, to allow a logical fillup of available projects available. Let me know what you think. 