### PR TITLE
Update sources and description on thrust allocation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,18 @@ Repo for mapping all the open source robotics software, including the ones from 
 - [Stonefish](https://stonefish.readthedocs.io/en/latest/) is a C++ library combining a physics engine and a lightweight rendering pipeline.
 - [TurtleBoat](https://github.com/bartboogmans/TurtleBoat) is an interactive node, similar to turtlebot, but then with vessel dynamics
 
-## Actuator control
-Modules that make sure that actuators follow a desired reference. 
-- The [general ros2 control community](https://control.ros.org/master/index.html)
+## Control effort allocation / Thruster-managers
+![pure_thrustallocation drawio (2)](https://github.com/bartboogmans/awesome-maritime-robotics/assets/5917472/82faf41e-1005-4574-a9df-bfa61f00853e)
+
+Modules that attempt to best satisfy a reference resultant force by the ships actuators, given a certain thruster layout. The goal is to decide on actuator actions (generally either force $f=[f_1,...,f_n]$ or utilization $u = [u_1,...,u_n]^{\intercal}$ and orientations $\alpha = [\alpha_1,...,\alpha_n]^{\intercal}$) of all $n$ thrusters that combined satisfy desired resultant forces. In most cases (e.g. propellers, not fins) they relate by:
+
+$$ \tau = T(\alpha)f(u) $$
+
+Where the forces per actuator $f$ depends on utilization $u$ and $T$ is the thrust allocation matrix (which is constant if actuator angles $\alpha$ are static). 
+
+- [MVP-Control](https://github.com/uri-ocean-robotics/mvp_control): A generic vehicle low-level vehicle controller (implements a control allocation algorithm with quadratic programming).
+- [CentraleNantesROV thrust_manager](https://github.com/CentraleNantesROV/thruster_manager): Uses URDF to get thruster info. Method: predefined T inverse lookup ( $f=T^{-1} * \tau$ )
+- [Robotic Decision Making Lab Oregon thrust manager](https://github.com/Robotic-Decision-Making-Lab/auv_controllers/tree/main/thruster_allocation_matrix_controller) Method: predefined T inverse lookup ( $f=T^{-1} * \tau$ )
 
 ## Motion control modules
 Components that attempt to control the vessels motion to follow a reference state. 
@@ -33,12 +42,13 @@ Approaches that are tailored to function with high surge speed, commonly neglect
 ### Other approaches
 - ...
 
-## Control effort allocation / Thruster-managers
-Modules that attempt to best satisfy a reference resultant force by the ships actuators, given a certain thruster layout. 
-- [MVP-Control](https://github.com/uri-ocean-robotics/mvp_control): A generic vehicle low-level vehicle controller (implements a control allocation algorithm with quadratic programming).
 
 ## Planning/Guidance mission-planning:
 - [MVP-Mission](https://github.com/uri-ocean-robotics/mvp_mission): A generic behavior-based state-oriented mission planner. It contains common behaviors for marine guidance.
+
+## Actuator control
+Modules that make sure that actuators follow a desired reference. Very vessel specific. 
+- The [general ros2 control community](https://control.ros.org/master/index.html)
 
 ## Drivers
 - [ping360_sonar](https://github.com/CentraleNantesRobotics/ping360_sonar)


### PR DESCRIPTION
1) Clarified the role of Thrust allocation blocks a little with some text and an image

2) Added two modules from projects that I have found that shared a solution. I tried to figure out the exact approach they used, and added that as well. I'll try to get in touch with the developers to give them a chance to verify this. 
